### PR TITLE
Add utility CSS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - `images-grayscale` - Grayscales images.
   - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
   - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
+  - `text-[left|center|right|justify]` - Aligns text.
 - Supports both light and dark modes.
 - Uses your Obsidian font settings, no annoying font overrides.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
   - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
   - `text-[left|center|right|justify]` - Aligns text.
+  - `text-monospace` - Makes text monospace (uses the monospace font set in your Obsidian settings).
 - Supports both light and dark modes.
 - Uses your Obsidian font settings, no annoying font overrides.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
   - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
   - `text-[left|center|right|justify]` - Aligns text.
-  - `text-monospace` - Makes text monospace (uses the monospace font set in your Obsidian settings).
+  - `font-monospace` - Makes text use your monospace font.
+  - `font-[thin|light|regular|medium|bold|black]` - Makes text a specific weight.
 - Supports both light and dark modes.
 - Uses your Obsidian font settings, no annoying font overrides.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
   - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
   - `text-[left|center|right|justify]` - Aligns text.
+  - `text-[uppercase|lowercase|capitalize]` - Changes text case.
   - `font-monospace` - Makes text use your monospace font.
   - `font-[thin|light|regular|medium|bold|black]` - Makes text a specific weight.
 - Supports both light and dark modes.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
 - Optional CSS snippets you can apply on a note-by-note basis with the `cssclasses` file property.
   - `images-invert` - Inverts images.
   - `images-grayscale` - Grayscales images.
+  - `images-sepia` - Sepias images.
   - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
   - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
   - `text-[left|center|right|justify]` - Aligns text.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - Dynamically hides the tab bar when only one tab is open.
   - Grayscale file properties unless hovered.
   - Other small tweaks to reduce clutter.
-- Optional CSS snippets you can apply on a note-by-note basis with the `cssclasses` file property.
+- Optional CSS rules you can apply on a note-by-note basis with the `cssclasses` file property.
   - `images-invert` - Inverts images.
   - `images-grayscale` - Grayscales images.
   - `images-sepia` - Sepias images.
@@ -26,7 +26,7 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
 - Supports both light and dark modes.
 - Uses your Obsidian font settings, no annoying font overrides.
 
-### Optional
+### Snippets
 
 These are optional CSS snippets you can use to customize your Obsidian further:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ The font shown in the screenshot is [Atkinson Hyperlegible](https://fonts.google
   - Dynamically hides the tab bar when only one tab is open.
   - Grayscale file properties unless hovered.
   - Other small tweaks to reduce clutter.
+- Optional CSS snippets you can apply on a note-by-note basis with the `cssclasses` file property.
+  - `images-invert` - Inverts images.
+  - `images-grayscale` - Grayscales images.
+  - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
+  - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
 - Supports both light and dark modes.
 - Uses your Obsidian font settings, no annoying font overrides.
 

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -1,51 +1,68 @@
-/* Apply filters to images */
+/* Invert images */
 .images-invert img {
   filter: invert(1);
 }
 
+/* Grayscale images */
 .images-grayscale img {
   filter: grayscale(1);
 }
 
+/* Blur images */
+.images-blur-sm img,
+.images-blur-md img,
+.images-blur-lg img {
+  transition: all 0.3s ease;
+}
+
+.images-blur-sm img:hover,
+.images-blur-md img:hover,
+.images-blur-lg img:hover {
+  filter: blur(0);
+}
+
+.images-blur-sm img {
+  filter: blur(5px);
+}
+
+.images-blur-md img {
+  filter: blur(10px);
+}
+
+.images-blur-lg img {
+  filter: blur(15px);
+}
+
+/* Make images square (remove rounded corners) */
+.images-square img {
+  border-radius: 0;
+}
+
 /* Scale images on hover */
-.images-hover-scale-105 img,
-.images-hover-scale-110 img,
-.images-hover-scale-115 img,
-.images-hover-scale-120 img,
-.images-hover-scale-125 img,
-.images-hover-scale-150 img,
-.images-hover-scale-200 img {
-  transition: transform 0.3s ease;
+.images-hover-scale-xs img,
+.images-hover-scale-sm img,
+.images-hover-scale-md img,
+.images-hover-scale-lg img,
+.images-hover-scale-xl img {
+  transition: all 0.3s ease;
 }
 
-.images-hover-scale-105 img:hover {
-  transform: scale(1.05);
-}
-
-.images-hover-scale-110 img:hover {
+.images-hover-scale-xs img:hover {
   transform: scale(1.1);
 }
 
-.images-hover-scale-115 img:hover {
-  transform: scale(1.15);
-}
-
-.images-hover-scale-120 img:hover {
+.images-hover-scale-sm img:hover {
   transform: scale(1.2);
 }
 
-.images-hover-scale-125 img:hover {
-  transform: scale(1.25);
+.images-hover-scale-md img:hover {
+  transform: scale(1.3);
 }
 
-.images-hover-scale-150 img:hover {
+.images-hover-scale-lg img:hover {
+  transform: scale(1.4);
+}
+
+.images-hover-scale-xl img:hover {
   transform: scale(1.5);
-}
-
-.images-hover-scale-200 img:hover {
-  transform: scale(2);
-}
-
-.images-square img {
-  border-radius: 0;
 }

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -1,6 +1,31 @@
 /* Monospace font */
-.text-monospace {
+.font-monospace {
   font-family: var(--font-monospace);
+}
+
+/* Font weights */
+.font-thin {
+  font-weight: 100;
+}
+
+.font-light {
+  font-weight: 300;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-black {
+  font-weight: 900;
 }
 
 /* Align text */

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -1,3 +1,8 @@
+/* Monospace font */
+.text-monospace {
+  font-family: var(--font-monospace);
+}
+
 /* Align text */
 .text-left {
   text-align: start;

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -1,3 +1,20 @@
+/* Align text */
+.text-left {
+  text-align: start;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: end;
+}
+
+.text-justify {
+  text-align: justify;
+}
+
 /* Invert images */
 .images-invert img {
   filter: invert(1);

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -1,0 +1,51 @@
+/* Apply filters to images */
+.images-invert img {
+  filter: invert(1);
+}
+
+.images-grayscale img {
+  filter: grayscale(1);
+}
+
+/* Scale images on hover */
+.images-hover-scale-105 img,
+.images-hover-scale-110 img,
+.images-hover-scale-115 img,
+.images-hover-scale-120 img,
+.images-hover-scale-125 img,
+.images-hover-scale-150 img,
+.images-hover-scale-200 img {
+  transition: transform 0.3s ease;
+}
+
+.images-hover-scale-105 img:hover {
+  transform: scale(1.05);
+}
+
+.images-hover-scale-110 img:hover {
+  transform: scale(1.1);
+}
+
+.images-hover-scale-115 img:hover {
+  transform: scale(1.15);
+}
+
+.images-hover-scale-120 img:hover {
+  transform: scale(1.2);
+}
+
+.images-hover-scale-125 img:hover {
+  transform: scale(1.25);
+}
+
+.images-hover-scale-150 img:hover {
+  transform: scale(1.5);
+}
+
+.images-hover-scale-200 img:hover {
+  transform: scale(2);
+}
+
+.images-square img {
+  border-radius: 0;
+}

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -30,6 +30,11 @@
   filter: grayscale(1);
 }
 
+/* Sepia images */
+.images-sepia img {
+  filter: sepia(1);
+}
+
 /* Blur images */
 .images-blur-sm img,
 .images-blur-md img,

--- a/src/cssclasses.css
+++ b/src/cssclasses.css
@@ -28,6 +28,19 @@
   font-weight: 900;
 }
 
+/* Text cases */
+.text-uppercase {
+  text-transform: uppercase;
+}
+
+.text-lowercase {
+  text-transform: lowercase;
+}
+
+.text-capitalize {
+  text-transform: capitalize;
+}
+
 /* Align text */
 .text-left {
   text-align: start;

--- a/theme.css
+++ b/theme.css
@@ -1,3 +1,54 @@
+/* Apply filters to images */
+.images-invert img {
+  filter: invert(1);
+}
+
+.images-grayscale img {
+  filter: grayscale(1);
+}
+
+/* Scale images on hover */
+.images-hover-scale-105 img,
+.images-hover-scale-110 img,
+.images-hover-scale-115 img,
+.images-hover-scale-120 img,
+.images-hover-scale-125 img,
+.images-hover-scale-150 img,
+.images-hover-scale-200 img {
+  transition: transform 0.3s ease;
+}
+
+.images-hover-scale-105 img:hover {
+  transform: scale(1.05);
+}
+
+.images-hover-scale-110 img:hover {
+  transform: scale(1.1);
+}
+
+.images-hover-scale-115 img:hover {
+  transform: scale(1.15);
+}
+
+.images-hover-scale-120 img:hover {
+  transform: scale(1.2);
+}
+
+.images-hover-scale-125 img:hover {
+  transform: scale(1.25);
+}
+
+.images-hover-scale-150 img:hover {
+  transform: scale(1.5);
+}
+
+.images-hover-scale-200 img:hover {
+  transform: scale(2);
+}
+
+.images-square img {
+  border-radius: 0;
+}
 /* Hide vault name */
 .nav-folder.mod-root > .nav-folder-title {
   display: none;

--- a/theme.css
+++ b/theme.css
@@ -1,6 +1,31 @@
 /* Monospace font */
-.text-monospace {
+.font-monospace {
   font-family: var(--font-monospace);
+}
+
+/* Font weights */
+.font-thin {
+  font-weight: 100;
+}
+
+.font-light {
+  font-weight: 300;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-medium {
+  font-weight: 500;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-black {
+  font-weight: 900;
 }
 
 /* Align text */

--- a/theme.css
+++ b/theme.css
@@ -1,53 +1,70 @@
-/* Apply filters to images */
+/* Invert images */
 .images-invert img {
   filter: invert(1);
 }
 
+/* Grayscale images */
 .images-grayscale img {
   filter: grayscale(1);
 }
 
+/* Blur images */
+.images-blur-sm img,
+.images-blur-md img,
+.images-blur-lg img {
+  transition: all 0.3s ease;
+}
+
+.images-blur-sm img:hover,
+.images-blur-md img:hover,
+.images-blur-lg img:hover {
+  filter: blur(0);
+}
+
+.images-blur-sm img {
+  filter: blur(5px);
+}
+
+.images-blur-md img {
+  filter: blur(10px);
+}
+
+.images-blur-lg img {
+  filter: blur(15px);
+}
+
+/* Make images square (remove rounded corners) */
+.images-square img {
+  border-radius: 0;
+}
+
 /* Scale images on hover */
-.images-hover-scale-105 img,
-.images-hover-scale-110 img,
-.images-hover-scale-115 img,
-.images-hover-scale-120 img,
-.images-hover-scale-125 img,
-.images-hover-scale-150 img,
-.images-hover-scale-200 img {
-  transition: transform 0.3s ease;
+.images-hover-scale-xs img,
+.images-hover-scale-sm img,
+.images-hover-scale-md img,
+.images-hover-scale-lg img,
+.images-hover-scale-xl img {
+  transition: all 0.3s ease;
 }
 
-.images-hover-scale-105 img:hover {
-  transform: scale(1.05);
-}
-
-.images-hover-scale-110 img:hover {
+.images-hover-scale-xs img:hover {
   transform: scale(1.1);
 }
 
-.images-hover-scale-115 img:hover {
-  transform: scale(1.15);
-}
-
-.images-hover-scale-120 img:hover {
+.images-hover-scale-sm img:hover {
   transform: scale(1.2);
 }
 
-.images-hover-scale-125 img:hover {
-  transform: scale(1.25);
+.images-hover-scale-md img:hover {
+  transform: scale(1.3);
 }
 
-.images-hover-scale-150 img:hover {
+.images-hover-scale-lg img:hover {
+  transform: scale(1.4);
+}
+
+.images-hover-scale-xl img:hover {
   transform: scale(1.5);
-}
-
-.images-hover-scale-200 img:hover {
-  transform: scale(2);
-}
-
-.images-square img {
-  border-radius: 0;
 }
 /* Hide vault name */
 .nav-folder.mod-root > .nav-folder-title {

--- a/theme.css
+++ b/theme.css
@@ -1,3 +1,8 @@
+/* Monospace font */
+.text-monospace {
+  font-family: var(--font-monospace);
+}
+
 /* Align text */
 .text-left {
   text-align: start;

--- a/theme.css
+++ b/theme.css
@@ -1,3 +1,20 @@
+/* Align text */
+.text-left {
+  text-align: start;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: end;
+}
+
+.text-justify {
+  text-align: justify;
+}
+
 /* Invert images */
 .images-invert img {
   filter: invert(1);

--- a/theme.css
+++ b/theme.css
@@ -30,6 +30,11 @@
   filter: grayscale(1);
 }
 
+/* Sepia images */
+.images-sepia img {
+  filter: sepia(1);
+}
+
 /* Blur images */
 .images-blur-sm img,
 .images-blur-md img,

--- a/theme.css
+++ b/theme.css
@@ -28,6 +28,19 @@
   font-weight: 900;
 }
 
+/* Text cases */
+.text-uppercase {
+  text-transform: uppercase;
+}
+
+.text-lowercase {
+  text-transform: lowercase;
+}
+
+.text-capitalize {
+  text-transform: capitalize;
+}
+
 /* Align text */
 .text-left {
   text-align: start;


### PR DESCRIPTION
Added the following CSS classes:
  - `images-invert` - Inverts images.
  - `images-grayscale` - Grayscales images.
  - `images-sepia` - Sepias images.
  - `images-blur-[sm|md|lg]` - Blurs images unless hovered.
  - `images-hover-scale-[xs|sm|md|lg|xl]` - Scales images on hover.
  - `text-[left|center|right|justify]` - Aligns text.
  - `text-[uppercase|lowercase|capitalize]` - Changes text case.
  - `font-monospace` - Makes text use your monospace font.
  - `font-[thin|light|regular|medium|bold|black]` - Makes text a specific weight.
